### PR TITLE
fix: radius rendering issue in DrawPolygon

### DIFF
--- a/examples/camera/main.go
+++ b/examples/camera/main.go
@@ -257,5 +257,10 @@ func addPentagon(space *cp.Space) {
 		shape = space.AddShape(cp.NewPolyShape(body, numVerts, verts, cp.NewTransformIdentity(), 0))
 		shape.SetElasticity(0)
 		shape.SetFriction(0.4)
+
+		if i > 5 {
+			poly := shape.Class.(*cp.PolyShape)
+			poly.SetRadius(10)
+		}
 	}
 }


### PR DESCRIPTION
There is an issue where the radius is not properly applied in the drawing process of DrawPolygon. This PR addresses that issue.

Currently, the drawing appears as shown in the following capture:
![2024-09-27 8 42 52](https://github.com/user-attachments/assets/43115c49-b4e3-4099-8fb1-e10817abac1a)


Ideally, the drawing should look like this:
![2024-09-27 8 41 57](https://github.com/user-attachments/assets/66a1c93e-dd24-4f59-a268-090323be1ce3)

After applying this PR, the result will be as shown below:
![2024-09-27 8 46 50](https://github.com/user-attachments/assets/76730fda-1b07-412d-a0a4-1742be791c99)
